### PR TITLE
design: Typography custom styles 정의, NotoSansKR 폰트 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,21 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import localFont from 'next/font/local'
+import { Noto_Sans_KR } from 'next/font/google'
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
   display: 'swap',
   weight: '45 920',
   variable: '--font-pretendard',
-});
+})
+
+const notoSansKr = Noto_Sans_KR({
+  subsets: ['latin'],
+  weight: ['400'],
+  display: 'swap',
+  variable: '--font-notoSans',
+})
 
 export const metadata: Metadata = {
   title: 'SPACE D',
@@ -21,11 +29,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`flex justify-center min-h-dvh ${pretendard.variable} font-pretendard`}>
-        <div className="w-full max-w-[430px] bg-black">
-          {children}
-        </div>
+      <body
+        className={`flex justify-center min-h-dvh ${pretendard.variable} font-pretendard ${notoSansKr.variable}`}
+      >
+        <div className="w-full max-w-[430px] bg-black">{children}</div>
       </body>
-    </html >
+    </html>
   )
 }

--- a/src/styles/theme/fontSize.ts
+++ b/src/styles/theme/fontSize.ts
@@ -1,0 +1,81 @@
+import { ThemeConfig } from 'tailwindcss/types/config'
+
+export const fontSize: ThemeConfig['fontSize'] = {
+  h1: [
+    '1.5rem',
+    {
+      lineHeight: '2rem',
+      fontWeight: '600',
+    },
+  ],
+  h2: [
+    '1.25rem',
+    {
+      lineHeight: '1.625rem',
+      fontWeight: '600',
+    },
+  ],
+  h3: [
+    '1rem',
+    {
+      lineHeight: '1.25rem',
+      fontWeight: '600',
+    },
+  ],
+  sub1: [
+    '1.125rem',
+    {
+      lineHeight: '1.5rem',
+      fontWeight: '500',
+    },
+  ],
+  sub2: [
+    '1rem',
+    {
+      lineHeight: '1.25rem',
+      fontWeight: '500',
+    },
+  ],
+  sub3: [
+    '0.875rem',
+    {
+      lineHeight: '1.125rem',
+      fontWeight: '500',
+    },
+  ],
+  body1: [
+    '1.125rem',
+    {
+      lineHeight: '1.5rem',
+      fontWeight: '400',
+    },
+  ],
+  body2: [
+    '1rem',
+    {
+      lineHeight: '1.25rem',
+      fontWeight: '400',
+    },
+  ],
+  body3: [
+    '0.875rem',
+    {
+      lineHeight: '1.125rem',
+      fontWeight: '400',
+    },
+  ],
+  caption: [
+    '0.75rem',
+    {
+      lineHeight: '1rem',
+      fontWeight: '400',
+    },
+  ],
+  phonetic: [
+    '0.875rem',
+    {
+      lineHeight: '1.25rem',
+      fontWeight: '400',
+    },
+  ],
+}

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -1,1 +1,2 @@
 export { colors } from './colors'
+export { fontSize } from './fontSize'

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
       colors,
       fontFamily: {
         pretendard: ['var(--font-pretendard)'],
+        notoSans: ['var(--font-notoSans)'],
       },
       screens: {
         xs: '360px',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from 'tailwindcss'
-import { colors } from './src/styles/theme/colors'
+import { colors, fontSize } from './src/styles/theme'
 
 const config: Config = {
   content: [
@@ -8,6 +8,7 @@ const config: Config = {
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
+    fontSize,
     extend: {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호
- close #25 
<br/>

## 📝 작업 내용

- styles/theme 위치에 fontSize.ts 생성하여 figma에 정의된 typography 정의한 후, 
tailwind.config theme에 추가

- color를 제외한 fontSize, lineHeight, fontWeight 정의

<br/>

## 📸 스크린샷

ex)
```js
<p className="text-h1">Pretendard, h1</p>
<p className="text-h1 font-notoSans">NotoSansKR, h1</p>
<p className="text-body1">Pretendard, body1</p>
<p className="text-caption">caption</p>
```
![image](https://github.com/user-attachments/assets/ccdd40ac-7ad9-4eb4-8314-3634e6f94d62)

<br/>

## 💬 리뷰 요구사항/참고 사항
정의한 typography 중 phonetic 스타일, NotoSansKR 폰트는 발음 기호 표기에만 사용됩니다.