### PR TITLE
design: 홈(메인) 페이지 WordItem 컴포넌트 UI 변경 사항 반영, custom Typography 적용 수정

### DIFF
--- a/src/app/dictionary/page.tsx
+++ b/src/app/dictionary/page.tsx
@@ -17,7 +17,7 @@ export default function DictionaryPage() {
       <div className="relative overflow-y-auto bg-background text-onSurface-300">
         <SearchHeader disabled={true} />
         <div className="flex flex-col px-4 gap-5 mt-[90px]">
-          <p className="text-xl font-semibold">
+          <p className="text-h2">
             등록된 실무 용어
             <span className="text-primary-400 ml-2">{totalCnt}</span>
           </p>

--- a/src/components/common/HorizontalScrollArea/index.tsx
+++ b/src/components/common/HorizontalScrollArea/index.tsx
@@ -1,7 +1,6 @@
 'use client'
-
 import Image from 'next/image'
-import { useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 type HorizontalScrollAreaProps = {
   children: React.ReactNode
@@ -13,6 +12,8 @@ export default function HorizontalScrollArea({
   title,
 }: HorizontalScrollAreaProps) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const [isStart, setIsStart] = useState<boolean>(true)
+  const [isEnd, setIsEnd] = useState<boolean>(false)
 
   const handlePrevClick = () => {
     scrollTo(-containerRef.current!.offsetWidth / 2)
@@ -29,7 +30,22 @@ export default function HorizontalScrollArea({
         behavior: 'smooth',
       })
     }
+    updateScrollPosition()
   }
+
+  // scroll 위치 업데이트
+  const updateScrollPosition = () => {
+    if (containerRef.current) {
+      const { scrollLeft, scrollWidth, clientWidth } = containerRef.current
+
+      setIsStart(scrollLeft <= 0)
+      setIsEnd(scrollLeft + clientWidth >= scrollWidth - 1)
+    }
+  }
+
+  useEffect(() => {
+    containerRef.current!.addEventListener('scroll', updateScrollPosition)
+  }, [])
 
   return (
     <div className="relative w-full overflow-hidden">
@@ -42,6 +58,7 @@ export default function HorizontalScrollArea({
             width={24}
             height={24}
             onClick={handlePrevClick}
+            className={isStart ? 'opacity-60' : 'opacity-100 cursor-pointer'}
           />
           <Image
             alt="right"
@@ -49,6 +66,7 @@ export default function HorizontalScrollArea({
             width={24}
             height={24}
             onClick={handleNextClick}
+            className={isEnd ? 'opacity-60' : 'opacity-100 cursor-pointer'}
           />
         </div>
       </div>

--- a/src/components/common/HorizontalScrollArea/index.tsx
+++ b/src/components/common/HorizontalScrollArea/index.tsx
@@ -15,11 +15,11 @@ export default function HorizontalScrollArea({
   const containerRef = useRef<HTMLDivElement>(null)
 
   const handlePrevClick = () => {
-    scrollTo(-containerRef.current!.offsetWidth + 16)
+    scrollTo(-containerRef.current!.offsetWidth / 2)
   }
 
   const handleNextClick = () => {
-    scrollTo(containerRef.current!.offsetWidth - 16)
+    scrollTo(containerRef.current!.offsetWidth / 2)
   }
 
   const scrollTo = (moveX: number) => {

--- a/src/components/common/HorizontalScrollArea/index.tsx
+++ b/src/components/common/HorizontalScrollArea/index.tsx
@@ -34,7 +34,7 @@ export default function HorizontalScrollArea({
   return (
     <div className="relative w-full overflow-hidden">
       <div className="flex overflow-hidden justify-between mb-3 px-4">
-        <p className="text-xl font-semibold text-[#f3f3f3] ">{title}</p>
+        <p className="text-h2 text-[#f3f3f3] ">{title}</p>
         <div className="flex gap-3">
           <Image
             alt="left"

--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -7,7 +7,9 @@ export type TagProps = {
 
 export default function Tag({ text, color }: TagProps) {
   return (
-    <span className={cn('w-fit py-1 px-[10px] rounded-[4px] text-xs', color)}>
+    <span
+      className={cn('w-fit py-1 px-[10px] rounded-[4px] text-[12px]', color)}
+    >
       {text}
     </span>
   )

--- a/src/components/domain/dictionary/OneWordItem/index.tsx
+++ b/src/components/domain/dictionary/OneWordItem/index.tsx
@@ -14,13 +14,13 @@ export default function OneWordItem({
       <div className="w-full px-4 py-6 border-b-[1px] border-outline">
         <div className="flex flex-col gap-1">
           <CategoryTag category={category} />
-          <p className="font-semibold text-lg">{name}</p>
+          <p className="text-sub1">{name}</p>
           <p className="text-onSurface-200 break-keep line-clamp-3">
             {meaning}
           </p>
         </div>
         {/* 하단 조회수, 댓글수 */}
-        <div className="flex gap-6 text-onSurface-200 mt-3 text-sm">
+        <div className="flex gap-6 text-onSurface-200 mt-3 text-body3">
           <div className="flex gap-1">
             <Image alt="view" src={'/icons/view.svg'} width={16} height={16} />
             <p>{viewCnt}</p>

--- a/src/components/domain/dictionary/TabFilter/index.tsx
+++ b/src/components/domain/dictionary/TabFilter/index.tsx
@@ -32,14 +32,15 @@ export default function TabFilter({
 
   return (
     <button
-      className={cn('w-fit px-3 py-2 rounded-full text-sm leading-[18px]', {
-        'bg-primary-400 text-background font-medium': isSelected,
-        'bg-none text-onSurface-300 font-normal outline outline-outline':
-          !isSelected,
+      className={cn('w-fit px-3 py-[7px] rounded-full ', {
+        'bg-primary-400 text-background': isSelected,
+        'bg-none text-onSurface-300 outline outline-outline': !isSelected,
       })}
       onClick={handleSelect}
     >
-      {filter}
+      <p className={cn({ 'text-sub3': isSelected, 'text-body3': !isSelected })}>
+        {filter}
+      </p>
     </button>
   )
 }

--- a/src/components/domain/home/Tabs/index.tsx
+++ b/src/components/domain/home/Tabs/index.tsx
@@ -20,7 +20,7 @@ export default function Tabs() {
       {tabList.map(({ label, path }, idx) => (
         <Link
           key={idx}
-          className={`w-1/2 text-center font-semibold text-xl border-b-4 pb-4 ${curPath === path ? 'text-[#47D3AD] border-b-[#47D3AD]' : 'text-white text-opacity-[0.87] border-b-[#fff] border-opacity-[0.15]'}`}
+          className={`w-1/2 text-center text-h2 border-b-4 pb-4 ${curPath === path ? 'text-[#47D3AD] border-b-[#47D3AD]' : 'text-white text-opacity-[0.87] border-b-[#fff] border-opacity-[0.15]'}`}
           href={`${path}`}
         >
           {label}

--- a/src/components/domain/home/dictionary/Bookmarks/index.tsx
+++ b/src/components/domain/home/dictionary/Bookmarks/index.tsx
@@ -9,7 +9,7 @@ export default function Bookmarks() {
       <div className="w-full flex flex-col gap-3 p-5 rounded-2xl bg-devBlue-400">
         <div className="flex gap-4">
           <div className="flex-1 flex flex-col gap-2 text-onSurface-300">
-            <p className="text-2xl font-semibold leading-8">별별 저장소 ⭐</p>
+            <p className="text-h1">별별 저장소 ⭐</p>
             <p className="leading-5">
               {isLoggedIn ? (
                 <>

--- a/src/components/domain/home/dictionary/PopularCommentsList/index.tsx
+++ b/src/components/domain/home/dictionary/PopularCommentsList/index.tsx
@@ -9,7 +9,7 @@ export default function PopularCommentsList({
   return (
     <div className="mx-4">
       <div className="w-full">
-        <p className="text-xl font-semibold text-[#f3f3f3] mb-3">
+        <p className="text-h2 text-[#f3f3f3] mb-3">
           지금 반응이 뜨거운 댓글 🔥
         </p>
         <ul className="flex flex-col gap-4 w-full">

--- a/src/components/domain/home/dictionary/ViewAllWords/index.tsx
+++ b/src/components/domain/home/dictionary/ViewAllWords/index.tsx
@@ -17,9 +17,7 @@ export default function ViewAllWords() {
           지금까지 등록된 실무 용어{' '}
           <span className="text-primary-200 font-semibold">100</span>개
         </p>
-        <p className="text-xl font-semibold leading-6 text-onSurface-300">
-          전체 실무 용어 보러가기
-        </p>
+        <p className="text-h2 text-onSurface-300">전체 실무 용어 보러가기</p>
       </div>
       <Image
         alt="보러가기"

--- a/src/components/domain/home/learning/CommunicationStats/CategoryChartItem.tsx
+++ b/src/components/domain/home/learning/CommunicationStats/CategoryChartItem.tsx
@@ -68,7 +68,7 @@ export default function CategoryChartItem({
             </p>
           </div>
         </div>
-        <p className="text-xs text-onSurface-200">
+        <p className="text-caption text-onSurface-200">
           <span className={values[category].textColor}>{cnt}</span>/{totalCnt}
           문제 정답
         </p>

--- a/src/components/domain/home/learning/CommunicationStats/TotalChart.tsx
+++ b/src/components/domain/home/learning/CommunicationStats/TotalChart.tsx
@@ -27,12 +27,10 @@ export default function TotalChart({ topPercent, percent }: TotalChartProps) {
             />
           </div>
           <div className="w-full absolute bottom-0 text-center">
-            <p className="text-xs leading-4 mb-[2px]">전체</p>
-            <p className={'text-2xl leading-6 font-semibold text-primary-200'}>
-              {Math.round(percent)}%
-            </p>
+            <p className="text-caption mb-[2px]">전체</p>
+            <p className={'text-h1 text-primary-200'}>{Math.round(percent)}%</p>
           </div>
-          <span className="absolute -top-[18px] -right-4 text-xs rounded py-1 px-2 bg-[#8C5EE4]">
+          <span className="absolute -top-[18px] -right-4 text-caption rounded py-1 px-2 bg-[#8C5EE4]">
             상위 {topPercent}%
           </span>
         </div>

--- a/src/components/domain/home/learning/CommunicationStats/index.tsx
+++ b/src/components/domain/home/learning/CommunicationStats/index.tsx
@@ -11,9 +11,7 @@ export default function CommunicationStats() {
       <div className="w-full flex flex-col items-center text-onSurface-300 px-4">
         <div className="w-full flex justify-between items-end mb-6">
           <div>
-            <p className="text-xl font-semibold mb-3">
-              나의 업무 소통 능력치 📊
-            </p>
+            <p className="text-h2 mb-3">나의 업무 소통 능력치 📊</p>
             <p className="text-onSurface-200">
               실무 용어 퀴즈로 단어를 학습하고 <br />
               소통 능력치를 높일 수 있어요.

--- a/src/components/domain/home/learning/TodayQuiz/index.tsx
+++ b/src/components/domain/home/learning/TodayQuiz/index.tsx
@@ -9,7 +9,7 @@ type TodayQuizProps = {
 export default function TodayQuiz({ todaySolvedCnt }: TodayQuizProps) {
   return (
     <div className="w-full px-4 text-onSurface-300 ">
-      <p className="text-xl font-semibold text-onSurface-300 mb-3">
+      <p className="text-h2 text-onSurface-300 mb-3">
         <span className="text-primary-400">{getTodayDate() + ' '}</span>
         실무 용어 퀴즈💫
       </p>
@@ -21,18 +21,16 @@ export default function TodayQuiz({ todaySolvedCnt }: TodayQuizProps) {
         }}
       >
         <div className="flex flex-col justify-between">
-          <p className="text-2xl font-semibold mb-2">실무 용어 퀴즈</p>
+          <p className="text-h1 mb-2">실무 용어 퀴즈</p>
           <p className="mb-5">
             오늘&nbsp;
-            <span className="text-primary-200 font-semibold">
-              {todaySolvedCnt}
-            </span>
+            <span className="text-primary-200 text-h3">{todaySolvedCnt}</span>
             명이 퀴즈에
             <br /> 참여했어요.
           </p>
           <Link
             href={'#'}
-            className="w-36 py-4 px-6 text-center font-medium bg-background rounded-lg"
+            className="w-36 py-4 px-6 text-center text-sub2 bg-background rounded-lg"
           >
             퀴즈 풀러 가기
           </Link>

--- a/src/components/shared/CommentItem/index.tsx
+++ b/src/components/shared/CommentItem/index.tsx
@@ -31,7 +31,7 @@ export default function CommentItem({
       className="flex flex-col gap-3 justify-between p-5 bg-gray-800 rounded-2xl"
     >
       <div className="flex justify-between">
-        <div className="flex gap-2">
+        <div className="flex gap-2 items-center">
           <Image
             src={'/images/logo.svg'}
             width={38}
@@ -39,8 +39,8 @@ export default function CommentItem({
             alt="profile"
           />
           <div>
-            <p className="text-onSurface-300 text-sm">{nickname}</p>
-            <p className="text-onSurface-200 text-xs">
+            <p className="text-onSurface-300 text-body3">{nickname}</p>
+            <p className="text-onSurface-200 text-caption">
               {jobGroup + ' · ' + company + ' · ' + experience}
             </p>
           </div>
@@ -71,9 +71,11 @@ export default function CommentItem({
             width={16}
             height={16}
           />
-          <p className="text-xs text-onSurface-200">{likeCount}</p>
+          <p className="text-caption text-onSurface-200">{likeCount}</p>
         </div>
-        <p className="text-xs text-onSurface-200">{getTimeAgo(createdAt)}</p>
+        <p className="text-caption text-onSurface-200">
+          {getTimeAgo(createdAt)}
+        </p>
       </div>
     </Link>
   )

--- a/src/components/shared/SearchHeader/index.tsx
+++ b/src/components/shared/SearchHeader/index.tsx
@@ -37,7 +37,7 @@ export default function SearchHeader({
           />
           {disabled && <div className="absolute inset-0 z-10" />}
           <input
-            className="w-full pl-12 py-[10px] pr-3 bg-gray-800 rounded-lg outline-none focus:outline-primary-400"
+            className="w-full pl-12 py-[10px] pr-3 bg-gray-800 rounded-lg outline-none text-body3 focus:outline-primary-400"
             placeholder="단어, 뜻, 예문, 발음으로 검색하기"
             disabled={disabled}
             onClick={handleClick}

--- a/src/components/shared/WordItem/index.tsx
+++ b/src/components/shared/WordItem/index.tsx
@@ -1,7 +1,8 @@
+'use client'
 import CategoryTag from '@/components/shared/CategoryTag'
 import { CategoryType } from '@/types/word'
-import Image from 'next/image'
 import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
 
 export type WordItemProps = {
   id: number
@@ -15,27 +16,35 @@ export default function WordItem({
   meaning,
   category,
 }: WordItemProps) {
+  const anchorRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState<number>(180)
+
+  useEffect(() => {
+    if (anchorRef.current) {
+      const anchorWidth = anchorRef.current.offsetWidth
+      setWidth(anchorWidth)
+    }
+  }, [])
+
   return (
     <Link
       href={`/word/${id}`}
-      className="min-w-full max-h-[152px] flex flex-col justify-between gap-3 py-5 rounded-xl px-5 text-white bg-gray-800 bg-opacity-outline"
+      className="w-min-[200px] w-max h-[140px] py-5 rounded-xl px-5 text-white bg-gray-800 bg-opacity-outline"
     >
-      <div className="flex flex-col justify-between">
-        <div className="flex justify-between mb-2">
-          <p className="text-sub1">{name}</p>
-          <Image
-            alt="북마크"
-            src={'/icons/bookmark.svg'}
-            width={24}
-            height={24}
-          />
+      <div className="w-max flex flex-col gap-2">
+        <CategoryTag category={category} />
+        <div ref={anchorRef} className={'flex gap-1 items-center shrink-0'}>
+          <p className="text-body1 shrink-0">{name}</p>
         </div>
-        <p className="text-body3 text-onSurface-200 mr-6 break-keep overflow-hidden line-clamp-2">
-          {meaning}
-        </p>
+        {width !== 0 && (
+          <p
+            style={{ width: width }}
+            className="text-body3 text-onSurface-200 break-keep overflow-hidden line-clamp-2"
+          >
+            {meaning}
+          </p>
+        )}
       </div>
-
-      <CategoryTag category={category} />
     </Link>
   )
 }

--- a/src/components/shared/WordItem/index.tsx
+++ b/src/components/shared/WordItem/index.tsx
@@ -22,7 +22,7 @@ export default function WordItem({
     >
       <div className="flex flex-col justify-between">
         <div className="flex justify-between mb-2">
-          <p className="text-lg font-medium leading-6">{name}</p>
+          <p className="text-sub1">{name}</p>
           <Image
             alt="북마크"
             src={'/icons/bookmark.svg'}
@@ -30,7 +30,7 @@ export default function WordItem({
             height={24}
           />
         </div>
-        <p className="text-sm leading-[18px] text-onSurface-200 mr-6 break-keep overflow-hidden line-clamp-2">
+        <p className="text-body3 text-onSurface-200 mr-6 break-keep overflow-hidden line-clamp-2">
           {meaning}
         </p>
       </div>


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호

- close #31 

<br/>

## 📝 작업 내용

- WordItem width 단어 길이에 맞게 너비 조정(useRef 사용)

- WordItem 내 북마크 아이콘 제거

- 홈(메인) 용어 목록 내 arrow icon- isStart, isEnd 상태에 따라 opacity 조절하여 disabled 상태 표기

- 카테고리 태그 위치 단어 위로 변경

- custom Typography로 변경하여 적용




<br/>

## 📸 스크린샷

**isStart, isEnd 상태에 따른 opacity 값 부여 및 UI 변경 사항 반영**
![화면 녹화 중 2024-08-15 165113](https://github.com/user-attachments/assets/7b7e3f43-2b7e-4ac5-8281-2e91e518d82d)


<br/>

## 💬 리뷰 요구사항/참고 사항

