### PR TITLE
design: Checkbox, RadioButton 스토리 작성 및 위치 이동

### DIFF
--- a/src/components/common/Checkbox/Checkbox.stories.tsx
+++ b/src/components/common/Checkbox/Checkbox.stories.tsx
@@ -8,11 +8,10 @@ const meta: Meta<typeof Checkbox> = {
   tags: ['autodocs'],
   argTypes: {
     isChecked: {
-      control: 'boolean',
+      description: '체크 유무를 결정합니다.',
     },
     text: {
-      control: 'text',
-      description: 'Label for the checkbox',
+      description: 'label에 표기할 텍스트를 입력합니다.',
     },
   },
 }

--- a/src/components/common/Checkbox/Checkbox.stories.tsx
+++ b/src/components/common/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useEffect, useState } from 'react'
+import Checkbox from '.'
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'components/common/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  argTypes: {
+    isChecked: {
+      control: 'boolean',
+    },
+    text: {
+      control: 'text',
+      description: 'Label for the checkbox',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Checkbox>
+
+export const Default: Story = {
+  render: (args) => {
+    const [isChecked, setIsChecked] = useState(args.isChecked)
+
+    useEffect(() => {
+      setIsChecked(args.isChecked)
+    }, [args.isChecked])
+
+    return (
+      <div className="text-onSurface-300">
+        <Checkbox
+          {...args}
+          isChecked={isChecked}
+          onChange={() => setIsChecked(!isChecked)}
+        />
+      </div>
+    )
+  },
+  args: {
+    isChecked: false,
+    text: 'checkbox',
+  },
+}

--- a/src/components/common/Checkbox/index.tsx
+++ b/src/components/common/Checkbox/index.tsx
@@ -1,19 +1,15 @@
 import { cn } from '@/lib/core'
-import React from 'react'
+import React, { ChangeEventHandler } from 'react'
 
 type CheckboxProps = {
   text: string
   isChecked: boolean
-  onChange: () => void
+  onChange: ChangeEventHandler<HTMLInputElement>
 }
 
-export default function OneCheckbox({
-  text,
-  isChecked,
-  onChange,
-}: CheckboxProps) {
+export default function Checkbox({ text, isChecked, onChange }: CheckboxProps) {
   return (
-    <label className="flex gap-3 py-4">
+    <label className="flex gap-3 py-4 items-center">
       <input
         type="checkbox"
         checked={isChecked}

--- a/src/components/common/RadioButton/RadioButton.stories.tsx
+++ b/src/components/common/RadioButton/RadioButton.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useEffect, useState } from 'react'
+import RadioButton from '.'
+
+const meta: Meta<typeof RadioButton> = {
+  title: 'components/common/RadioButton',
+  component: RadioButton,
+  tags: ['autodocs'],
+  argTypes: {
+    id: {
+      description: '각 RadioButton를 구분하는 value를 결정합니다.',
+    },
+    isChecked: {
+      description: '선택 유무를 결정합니다.',
+    },
+    item: {
+      description: 'label에 표기할 텍스트를 입력합니다.',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof RadioButton>
+
+export const Default: Story = {
+  render: (args) => {
+    const [isChecked, setIsChecked] = useState(args.isChecked)
+
+    useEffect(() => {
+      setIsChecked(args.isChecked)
+    }, [args.isChecked])
+
+    return (
+      <div className="text-onSurface-300">
+        <RadioButton
+          {...args}
+          isChecked={isChecked}
+          onChange={() => setIsChecked(!isChecked)}
+        />
+      </div>
+    )
+  },
+  args: {
+    isChecked: false,
+    item: 'radioButton',
+  },
+}

--- a/src/components/common/RadioButton/index.tsx
+++ b/src/components/common/RadioButton/index.tsx
@@ -1,18 +1,19 @@
 import { cn } from '@/lib/core'
+import { ChangeEventHandler } from 'react'
 
-type OneRadioBtnProps = {
+type RadioButtonProps = {
   id: number
   item: string
   isChecked: boolean
-  onChange: () => void
+  onChange: ChangeEventHandler<HTMLInputElement>
 }
 
-export default function OneRadioBtn({
+export default function RadioButton({
   id,
   item,
   isChecked,
   onChange,
-}: OneRadioBtnProps) {
+}: RadioButtonProps) {
   return (
     <label className="text-sub2 flex items-center gap-3 py-4">
       <input

--- a/src/components/shared/CheckboxBottomSheet/index.tsx
+++ b/src/components/shared/CheckboxBottomSheet/index.tsx
@@ -2,8 +2,8 @@ import BottomSheet from '@/components/common/BottomSheet'
 import { CHECKBOX_MENUS } from '@/constants/bottomSheet'
 import useUIStore from '@/store/useUIStore'
 import { useState } from 'react'
-import OneCheckbox from './OneCheckbox'
 import Button from '@/components/common/Button'
+import Checkbox from '@/components/common/Checkbox'
 
 type BottomSheetProps = {
   isOpen: boolean
@@ -43,7 +43,7 @@ export default function CheckboxBottomSheet({
       <p className="text-body2 text-onSurface-200 mb-5">{description}</p>
       <ul className="mb-5">
         {options.map(({ id, text }, idx) => (
-          <OneCheckbox
+          <Checkbox
             key={id}
             text={text}
             isChecked={checked.has(id)}

--- a/src/components/shared/RadioBtnBottomSheet/index.tsx
+++ b/src/components/shared/RadioBtnBottomSheet/index.tsx
@@ -1,7 +1,7 @@
 import BottomSheet from '@/components/common/BottomSheet'
 import { RADIOBTN_MENUS } from '@/constants/bottomSheet'
-import OneRadioBtn from './OneRadioBtn'
 import Button from '@/components/common/Button'
+import RadioButton from '@/components/common/RadioButton'
 
 type BottomSheetProps = {
   isOpen: boolean
@@ -27,7 +27,7 @@ export default function RadioBtnBottomSheet({
       <p className="text-h2 mb-5">{`${nickname}님,` + `\n` + title}</p>
       <ul className="mb-5">
         {options.map(({ id, item }, idx) => (
-          <OneRadioBtn
+          <RadioButton
             key={id}
             id={id}
             isChecked={value === id}


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호
- close #39 

<br/>

## 📝 작업 내용

- `CheckboxBottomSheet`, `RadioBtnBottomSheet` 하위에 있던 `OneCheckbox`, `OneRadioBtn`  각각 **`components/common`** 위치 이동 및 컴포넌트 이름 변경
- Checkbox, RadioButton 스토리 작성

<br/>

## 📸 스크린샷

Checkbox, RadioButton 컴포넌트 스토리 작성

![image](https://github.com/user-attachments/assets/3d52417a-9e8b-4dd3-a4f3-dc955d87003f)
![image](https://github.com/user-attachments/assets/3dae9be2-3c2a-455d-ab3b-b5c3c0d39af2)


<br/>

## 💬 리뷰 요구사항/참고 사항
1. 현재 디자인에서는 checkbox, radio 타입의 input이 바텀시트 내부에서만 사용되기 때문에 관련 bottomSheet 폴더 하위에 OneCheckbox, OneRadioBtn 컴포넌트를 생성했었지만 추후에 디자인 변경에 따라 재사용 가능성이 높은 요소라 components/common 하위에 Checkbox, RadioButton 이름으로 변경 및 이동했습니다.
