### PR TITLE
feat: EmptyLayout 컴포넌트 UI 작업

### DIFF
--- a/src/components/shared/EmptyLayout/index.tsx
+++ b/src/components/shared/EmptyLayout/index.tsx
@@ -1,0 +1,31 @@
+'use client'
+import Button from '@/components/common/Button'
+import { EMPTY_LAYOUT } from '@/constants/emptyLayout'
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+
+export type EmptyLayoutProps = {
+  target: 'likeComments' | 'myComments' | 'bookmarks' | 'searchResults'
+}
+
+export default function EmptyLayout({ target }: EmptyLayoutProps) {
+  const router = useRouter()
+  const { image, title, description, btnText } = EMPTY_LAYOUT[target]
+  const isLoggedIn = false
+  return (
+    <div className="w-full h-full flex flex-col gap-4 justify-center items-center px-12">
+      <Image src={`/images/${image}`} alt="img" width={80} height={80} />
+      <p className="text-h2 text-onSurface-300">{title}</p>
+      {description && (
+        <p className="text-body1 text-onSurface-200 text-center">
+          {isLoggedIn ? description[0] : description[1]}
+        </p>
+      )}
+      {btnText && (
+        <Button type="gradient" onClick={() => router.push('/dictionary')}>
+          <p>{btnText}</p>
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/constants/emptyLayout.ts
+++ b/src/constants/emptyLayout.ts
@@ -1,0 +1,34 @@
+import { EmptyLayoutProps } from '@/components/shared/EmptyLayout'
+
+export const EMPTY_LAYOUT: {
+  [key in EmptyLayoutProps['target']]: {
+    image: string
+    title: string
+    description?: string | string[]
+    btnText?: string
+  }
+} = {
+  likeComments: {
+    image: 'logo.svg',
+    title: '좋아요 한 댓글이 없어요.',
+    btnText: '실무 용어 탐색하기',
+  },
+  myComments: {
+    image: 'logo.svg',
+    title: '작성한 댓글이 없어요.',
+    btnText: '실무 용어 탐색하기',
+  },
+  bookmarks: {
+    image: 'logo.svg',
+    title: '저장소가 비어있어요.',
+    description: [
+      '별 단어가 다 있다고 생각이 드는\n실무 용어를 별별 저장소에 등록해보세요.',
+      '로그인을 하고 별 단어가 다 있다고 생각이 드는\n실무 용어를 별별 저장소에 등록해보세요.',
+    ],
+    btnText: '등록하러 가기',
+  },
+  searchResults: {
+    image: 'logo.svg',
+    title: '검색된 실무 용어가 없어요.',
+  },
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호
- close #45 

<br/>

## 📝 작업 내용
- EmptyLayout에서 페이지별로 표기할 텍스트 `constants` 파일에 상수화
- target의 타입 미리 지정해서 어느 페이지에 대한 EmptyLayout인지 props 전달하도록 구현

<br/>

## 📸 스크린샷

<div>
<img src="https://github.com/user-attachments/assets/d6a41eb2-6332-43d7-a8cd-ca467c617ad8" width='200px'/>
<img src="https://github.com/user-attachments/assets/e8d116bf-9580-4a7a-976b-559057f1df2e" width='200px'/>
</div>

<div>
<img src="https://github.com/user-attachments/assets/ff142f1f-22f3-45ae-8394-97198e231345" width='200px'/>
<img src="https://github.com/user-attachments/assets/b964bf69-2e71-4d15-8141-478484f0a8c0" width='200px'/>
<img src="https://github.com/user-attachments/assets/e36bd861-1017-4cf8-afc1-3730962353d6" width='200px'/>
</div>

<br/>

## 💬 리뷰 요구사항/참고 사항
- image는 일러스트 나오면 적용할 예정입니다~
