### PR TITLE
feat: HighlightText 공통 컴포넌트 구현, 스토리 작성

### DIFF
--- a/src/components/common/HighlightText/HighlightText.stories.tsx
+++ b/src/components/common/HighlightText/HighlightText.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import HighlightText from '.'
+
+const meta: Meta<typeof HighlightText> = {
+  title: 'components/common/HighlightText',
+  component: HighlightText,
+  tags: ['autodocs'],
+  argTypes: {
+    text: {
+      description: 'target 단어를 포함한 `전체 문장 또는 단어`입니다.',
+    },
+    target: {
+      description:
+        '`#00946D`으로 highlight 하고싶은 `특정 단어`입니다.<br/>(대소문자 구분X)',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof HighlightText>
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div className="bg-gray-200">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    text: '“우리는 애자일(Agile)한 조직으로 변모하기 위해 노력해왔습니다. 1년 동안 모두가 힘써주신 덕분에 높은 성과를 낼 수 있었어요.”',
+    target: '애자일(Agile)',
+  },
+}

--- a/src/components/common/HighlightText/HighlightText.stories.tsx
+++ b/src/components/common/HighlightText/HighlightText.stories.tsx
@@ -10,8 +10,14 @@ const meta: Meta<typeof HighlightText> = {
       description: 'target 단어를 포함한 `전체 문장 또는 단어`입니다.',
     },
     target: {
-      description:
-        '`#00946D`으로 highlight 하고싶은 `특정 단어`입니다.<br/>(대소문자 구분X)',
+      description: 'highlight 하고싶은 `특정 단어`입니다.<br/>(대소문자 구분X)',
+    },
+    variant: {
+      description: '카테고리 종류입니다.',
+      control: {
+        type: 'radio',
+      },
+      options: [null, '비즈니스', '디자인', '개발'],
     },
   },
 }

--- a/src/components/common/HighlightText/index.tsx
+++ b/src/components/common/HighlightText/index.tsx
@@ -1,0 +1,28 @@
+export type HighlightTextProps = {
+  text: string
+  target: string
+}
+
+export default function HighlightText({ text, target }: HighlightTextProps) {
+  const escapeRegExp = (str: string) => {
+    return str.replace(/[()]/g, '\\$&') // 특수 문자 이스케이프 처리
+  }
+
+  const regex = new RegExp(`(${escapeRegExp(target)})`, 'g') // target 기준으로 split하지만 ()에 포함시켜 target 포함하여 배열 반환
+
+  const splitted = text.split(regex)
+
+  return (
+    <p className="text-sub2 text-background">
+      {splitted.map((item, idx) =>
+        item === target ? (
+          <span key={idx} className="text-[#00946D]">
+            {item}
+          </span>
+        ) : (
+          item
+        ),
+      )}
+    </p>
+  )
+}

--- a/src/components/common/HighlightText/index.tsx
+++ b/src/components/common/HighlightText/index.tsx
@@ -1,22 +1,32 @@
 export type HighlightTextProps = {
   text: string
   target: string
+  variant?: '비즈니스' | '디자인' | '개발'
 }
 
-export default function HighlightText({ text, target }: HighlightTextProps) {
+const BASE_COLOR = 'text-primary-400'
+const COLORS = {
+  비즈니스: 'text-[#00946D]',
+  디자인: 'text-[#A233CB]',
+  개발: 'text-[#2C6DC0]',
+}
+
+export default function HighlightText({
+  text,
+  target,
+  variant,
+}: HighlightTextProps) {
   const escapeRegExp = (str: string) => {
     return str.replace(/[()]/g, '\\$&') // 특수 문자 이스케이프 처리
   }
-
   const regex = new RegExp(`(${escapeRegExp(target)})`, 'gi') // target 기준으로 split하지만 ()에 포함시켜 target 포함하여 배열 반환
-
   const splitted = text.split(regex)
 
   return (
-    <p className="text-sub2 text-background">
+    <p>
       {splitted.map((item, idx) =>
         item.toLocaleLowerCase() === target.toLocaleLowerCase() ? (
-          <span key={idx} className="text-[#00946D]">
+          <span key={idx} className={variant ? COLORS[variant] : BASE_COLOR}>
             {item}
           </span>
         ) : (

--- a/src/components/common/HighlightText/index.tsx
+++ b/src/components/common/HighlightText/index.tsx
@@ -8,14 +8,14 @@ export default function HighlightText({ text, target }: HighlightTextProps) {
     return str.replace(/[()]/g, '\\$&') // 특수 문자 이스케이프 처리
   }
 
-  const regex = new RegExp(`(${escapeRegExp(target)})`, 'g') // target 기준으로 split하지만 ()에 포함시켜 target 포함하여 배열 반환
+  const regex = new RegExp(`(${escapeRegExp(target)})`, 'gi') // target 기준으로 split하지만 ()에 포함시켜 target 포함하여 배열 반환
 
   const splitted = text.split(regex)
 
   return (
     <p className="text-sub2 text-background">
       {splitted.map((item, idx) =>
-        item === target ? (
+        item.toLocaleLowerCase() === target.toLocaleLowerCase() ? (
           <span key={idx} className="text-[#00946D]">
             {item}
           </span>

--- a/src/components/domain/wordDetail/WordInfo/index.tsx
+++ b/src/components/domain/wordDetail/WordInfo/index.tsx
@@ -1,3 +1,4 @@
+import HighlightText from '@/components/common/HighlightText'
 import HorizontalScrollArea from '@/components/common/HorizontalScrollArea'
 import CategoryTag from '@/components/shared/CategoryTag'
 import { DetailWordType } from '@/types/word'
@@ -46,7 +47,7 @@ export default function WordInfo({ word }: { word: DetailWordType }) {
           {example.map((example, idx) => (
             <div key={idx} className="min-w-fit">
               <div className="max-w-[calc(100%-9px)] relative bg-gray-200 h-fit py-6 px-5 rounded-2xl">
-                <p className="text-sub2 text-background break-keep">{`"${example.text}"`}</p>
+                <HighlightText text={`"${example.text}"`} target={name} />
                 <Image
                   alt="bubble"
                   src={'/images/bubble_tail.svg'}

--- a/src/components/domain/wordDetail/WordInfo/index.tsx
+++ b/src/components/domain/wordDetail/WordInfo/index.tsx
@@ -46,7 +46,7 @@ export default function WordInfo({ word }: { word: DetailWordType }) {
         <HorizontalScrollArea title="예문" titleSize="small" scrollDivisor={1}>
           {example.map((example, idx) => (
             <div key={idx} className="min-w-fit">
-              <div className="max-w-[calc(100%-9px)] relative bg-gray-200 h-fit py-6 px-5 rounded-2xl">
+              <div className="max-w-[calc(100%-9px)] h-fit relative bg-gray-200 text-background text-sub2 py-6 px-5 rounded-2xl">
                 <HighlightText text={`"${example.text}"`} target={name} />
                 <Image
                   alt="bubble"


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호
- close #48 

<br/>

## 📝 작업 내용

- 용어 상세 페이지, 용어 퀴즈 페이지 예문 내에서 특정 단어를 highlight 처리하기 위한 공통 컴포넌트 구현했습니다.
(text, target props 전달)
- 정규식에서 gi 플래그 적용, splitted 배열 요소와 일치하는지 확인 시 `toLocaleLowerCase()` 적용을 통해 대소문자 구분 없이 target단어 찾도록 했습니다.(검색 자동 완성 내에서 대소문자 구분 없이 highlight하기 위해)
- 스토리 작성 완료했습니다.

<br/>

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/6a1a1fb4-1125-4deb-a259-bd92a7311b09)
<br/>

스토리에서만 배경색 적용
![image](https://github.com/user-attachments/assets/63f90330-902b-4f1e-a214-474bfce2119d)


<br/>

## 💬 리뷰 요구사항/참고 사항
1. 현재 피그마 기준으로 검색 자동 완성 페이지 용어 목록에서 input값에 대해 highlight이 적용되지 않은 상태이긴 합니다. 적용하는 방향으로 간다면 highlight 색상이 `#00946D`로 고정인지에 따라 수정 필요합니다.
2. 용어 퀴즈 내 예문에 사용하시면 될 것 같습니다~