### PR TITLE
feat: (관리자) 용어 등록 페이지 UI 작업 및 admin 페이지 레이아웃 변경

### DIFF
--- a/src/api/admin/words/index.ts
+++ b/src/api/admin/words/index.ts
@@ -1,0 +1,7 @@
+import { get } from '@/lib/axios'
+import { AdminWordType } from '@/types/word'
+
+export async function getWordDetailById(wordId: number) {
+  const res = await get<AdminWordType>(`/admin/words/${wordId}`)
+  return res
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+const MENUS = [
+  { name: '용어 목록', path: '/admin/words' },
+  { name: '용어 등록', path: '/admin/word/add' },
+  { name: '신고 댓글 관리', path: '/admin/reports' },
+]
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="w-full h-full bg-gray-100 text-background">
+      <nav className="flex gap-8 justify-around py-4 bg-white shadow-sm items-center">
+        <div className="flex gap-2 items-center">
+          <Image
+            alt="logo.svg"
+            src={'/images/logo.svg'}
+            width={32}
+            height={32}
+          />
+          <p className="text-h2">Space D</p>
+        </div>
+        <div className="flex gap-8">
+          {MENUS.map((menu, idx) => (
+            <Link key={idx} href={menu.path} className="hover:text-h3">
+              {menu.name}
+            </Link>
+          ))}
+        </div>
+        <Link
+          href={'/home/learning'}
+          className="text-gray-400 hover:text-gray-600"
+        >
+          서비스 메인으로
+        </Link>
+      </nav>
+      {children}
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 const MENUS = [
   { name: '용어 목록', path: '/admin/words' },
   { name: '용어 등록', path: '/admin/words/add' },
-  { name: '신고 댓글 관리', path: '/admin/reports' },
+  { name: '신고 댓글', path: '/admin/reports' },
 ]
 
 export default function AdminLayout({
@@ -14,8 +14,8 @@ export default function AdminLayout({
 }) {
   return (
     <div className="w-full h-full bg-gray-100 text-background">
-      <nav className="flex gap-8 justify-around py-4 bg-white shadow-sm items-center">
-        <div className="flex gap-2 items-center">
+      <nav className="flex gap-8 max-lg:gap-2 justify-around py-4 bg-white shadow-sm items-center shrink-0">
+        <div className="flex gap-2 items-center max-lg:hidden">
           <Image
             alt="logo.svg"
             src={'/images/logo.svg'}
@@ -24,7 +24,7 @@ export default function AdminLayout({
           />
           <p className="text-h2">Space D</p>
         </div>
-        <div className="flex gap-8">
+        <div className="flex gap-8 max-lg:gap-3">
           {MENUS.map((menu, idx) => (
             <Link key={idx} href={menu.path} className="hover:text-h3">
               {menu.name}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 const MENUS = [
   { name: '용어 목록', path: '/admin/words' },
-  { name: '용어 등록', path: '/admin/word/add' },
+  { name: '용어 등록', path: '/admin/words/add' },
   { name: '신고 댓글 관리', path: '/admin/reports' },
 ]
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+
+export default function AdminMagePage() {
+  return <></>
+}

--- a/src/app/admin/word/add/page.tsx
+++ b/src/app/admin/word/add/page.tsx
@@ -1,0 +1,133 @@
+'use client'
+import Button from '@/components/common/Button'
+import Input from '@/components/common/Input'
+import RadioButton from '@/components/common/RadioButton'
+import Textarea from '@/components/common/Textarea'
+import { useState } from 'react'
+
+type AdminWordType = {
+  name: string
+  meaning: string
+  pronunciation: {
+    english: string
+  }
+  category: string
+  example: string
+}
+
+const CATEGORY = [
+  { id: 0, name: '비즈니스' },
+  { id: 1, name: '디자인' },
+  { id: 2, name: '개발' },
+]
+
+export default function AddWordPage() {
+  const [word, setWord] = useState<AdminWordType>({
+    name: '',
+    meaning: '',
+    pronunciation: { english: '' },
+    category: '',
+    example: '',
+  })
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value, type } = e.target
+    if (type === 'radio') {
+      const category = CATEGORY.find((item) => item.id === parseInt(value))
+      const categoryName = category ? category.name : ''
+      setWord((prev) => ({
+        ...prev,
+        category: categoryName,
+      }))
+    } else if (name === 'pronunciation') {
+      setWord((prev) => ({ ...prev, pronunciation: { english: value } }))
+    } else {
+      setWord((prev) => ({ ...prev, [name]: value }))
+    }
+    console.log(word)
+  }
+  function hasEmptyField() {
+    const { name, meaning, pronunciation, category, example } = word
+    return (
+      name === '' ||
+      meaning === '' ||
+      pronunciation.english === '' ||
+      category === '' ||
+      example === ''
+    )
+  }
+
+  const handleSubmit = () => {
+    if (hasEmptyField()) {
+      alert('모두 입력해주세요')
+      return
+    }
+    alert(`${word.name} 용어 등록 완료`)
+  }
+
+  return (
+    <>
+      <div className="mx-72 mt-8">
+        <p className="text-h2 mb-6">용어 등록</p>
+        <div className="flex flex-col gap-6">
+          <label>
+            용어 이름{' '}
+            <Input
+              name="name"
+              value={word.name ?? ''}
+              onChange={handleChange}
+            />
+          </label>
+
+          <label>
+            용어 뜻{' '}
+            <Textarea
+              name="meaning"
+              value={word.meaning ?? ''}
+              onChange={handleChange}
+              className="bg-white"
+            />
+          </label>
+          <label>
+            예문{' '}
+            <Textarea
+              name="example"
+              value={word.example ?? ''}
+              onChange={handleChange}
+              className="bg-white"
+            />
+          </label>
+
+          <label>
+            발음
+            <Input
+              name="pronunciation"
+              value={word.pronunciation.english ?? ''}
+              onChange={handleChange}
+            />
+          </label>
+          <fieldset>
+            <label>카테고리</label>
+            {CATEGORY.map((item) => (
+              <RadioButton
+                key={item.id}
+                id={item.id}
+                item={item.name}
+                onChange={handleChange}
+                isChecked={word.category === item.name}
+              />
+            ))}
+          </fieldset>
+          <Button
+            type={hasEmptyField() ? 'disabled' : 'gradient'}
+            isFullWidth
+            onClick={handleSubmit}
+          >
+            용어 등록
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/app/admin/words/[slug]/page.tsx
+++ b/src/app/admin/words/[slug]/page.tsx
@@ -1,0 +1,27 @@
+import { getWordDetailById } from '@/api/admin/words'
+import WordDetail from '@/components/domain/admin/WordDetail'
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from '@tanstack/react-query'
+
+export default async function WordDetailPage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const wordId = parseInt(params.slug.split('/').at(-1) ?? '')
+  const queryClient = new QueryClient()
+
+  await queryClient.prefetchQuery({
+    queryKey: ['words', 'admin', wordId],
+    queryFn: () => getWordDetailById(wordId),
+  })
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <WordDetail wordId={wordId} />
+    </HydrationBoundary>
+  )
+}

--- a/src/app/admin/words/add/page.tsx
+++ b/src/app/admin/words/add/page.tsx
@@ -3,17 +3,8 @@ import Button from '@/components/common/Button'
 import Input from '@/components/common/Input'
 import RadioButton from '@/components/common/RadioButton'
 import Textarea from '@/components/common/Textarea'
+import { AddWordType } from '@/types/word'
 import { useState } from 'react'
-
-type AdminWordType = {
-  name: string
-  meaning: string
-  pronunciation: {
-    english: string
-  }
-  category: string
-  example: string
-}
 
 const CATEGORY = [
   { id: 0, name: '비즈니스' },
@@ -22,11 +13,11 @@ const CATEGORY = [
 ]
 
 export default function AddWordPage() {
-  const [word, setWord] = useState<AdminWordType>({
+  const [word, setWord] = useState<AddWordType>({
     name: '',
     meaning: '',
-    pronunciation: { english: '' },
-    category: '',
+    pronunciationInfo: { english: '' },
+    category: '비즈니스',
     example: '',
   })
   const handleChange = (
@@ -36,7 +27,7 @@ export default function AddWordPage() {
     if (type === 'radio') {
       const category = CATEGORY.find((item) => item.id === parseInt(value))
       const categoryName = category ? category.name : ''
-      setWord((prev) => ({
+      setWord((prev: any) => ({
         ...prev,
         category: categoryName,
       }))
@@ -48,12 +39,11 @@ export default function AddWordPage() {
     console.log(word)
   }
   function hasEmptyField() {
-    const { name, meaning, pronunciation, category, example } = word
+    const { name, meaning, pronunciationInfo, category, example } = word
     return (
       name === '' ||
       meaning === '' ||
-      pronunciation.english === '' ||
-      category === '' ||
+      pronunciationInfo.english === '' ||
       example === ''
     )
   }
@@ -93,7 +83,7 @@ export default function AddWordPage() {
             예문{' '}
             <Textarea
               name="example"
-              value={word.example ?? ''}
+              value={(word.example as string) ?? ''}
               onChange={handleChange}
               className="bg-white"
             />
@@ -103,7 +93,7 @@ export default function AddWordPage() {
             발음
             <Input
               name="pronunciation"
-              value={word.pronunciation.english ?? ''}
+              value={word.pronunciationInfo.english ?? ''}
               onChange={handleChange}
             />
           </label>

--- a/src/app/admin/words/add/page.tsx
+++ b/src/app/admin/words/add/page.tsx
@@ -58,7 +58,7 @@ export default function AddWordPage() {
 
   return (
     <>
-      <div className="mx-72 mt-8">
+      <div className="mx-72 mt-8 max-lg:mx-4">
         <p className="text-h2 mb-6">용어 등록</p>
         <div className="flex flex-col gap-6">
           <label>

--- a/src/app/admin/words/add/page.tsx
+++ b/src/app/admin/words/add/page.tsx
@@ -31,15 +31,15 @@ export default function AddWordPage() {
         ...prev,
         category: categoryName,
       }))
-    } else if (name === 'pronunciation') {
-      setWord((prev) => ({ ...prev, pronunciation: { english: value } }))
+    } else if (name === 'pronunciationInfo') {
+      setWord((prev) => ({ ...prev, pronunciationInfo: { english: value } }))
     } else {
       setWord((prev) => ({ ...prev, [name]: value }))
     }
     console.log(word)
   }
   function hasEmptyField() {
-    const { name, meaning, pronunciationInfo, category, example } = word
+    const { name, meaning, pronunciationInfo, example } = word
     return (
       name === '' ||
       meaning === '' ||
@@ -92,7 +92,7 @@ export default function AddWordPage() {
           <label>
             발음
             <Input
-              name="pronunciation"
+              name="pronunciationInfo"
               value={word.pronunciationInfo.english ?? ''}
               onChange={handleChange}
             />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css'
 import localFont from 'next/font/local'
 import { Noto_Sans_KR } from 'next/font/google'
 import QueryProvider from '@/provider/QueryProvider'
+import { headers } from 'next/headers'
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
@@ -28,12 +29,18 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const heads = headers()
+  const pathname = heads.get('x-current-path')
+  const isAdminPage = pathname?.startsWith('/admin')
+
   return (
     <html lang="en">
       <body
         className={`flex justify-center min-h-dvh ${pretendard.variable} font-pretendard ${notoSansKr.variable}`}
       >
-        <div className="w-full max-w-[430px] bg-background whitespace-pre-wrap">
+        <div
+          className={`w-full ${isAdminPage ? '' : 'max-w-[430px]'} bg-black whitespace-pre-wrap`}
+        >
           <QueryProvider>{children}</QueryProvider>
         </div>
       </body>

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -25,7 +25,7 @@ export default function Button({
           'bg-btn-gradient hover:bg-btn-gradient-hover text-background':
             type === 'gradient',
           'bg-background': type === 'black',
-          'bg-gray-800 text-onSurface-100': type === 'disabled',
+          'bg-gray-800 text-onSurface-100 cursor-default': type === 'disabled',
           'bg-gray-600 hover:bg-gray-500': type === 'light',
           'w-full': isFullWidth,
         },

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/core'
+import { InputHTMLAttributes, forwardRef } from 'react'
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+export default forwardRef<HTMLInputElement, InputProps>(function Input(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <input
+      ref={ref}
+      {...props}
+      className={cn(
+        'resize-none w-full flex items-center justify-center py-4 px-4 rounded-lg outline outline-[0.5px] outline-primary-400 focus:outline-[1.5px] ',
+        className,
+      )}
+      onChange={props.onChange}
+    />
+  )
+})

--- a/src/components/domain/admin/WordDetail/index.tsx
+++ b/src/components/domain/admin/WordDetail/index.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { useGetWordDetail } from '@/hooks/admin/useGetDetailWord'
+
+export default function WordDetail({ wordId }: { wordId: number }) {
+  const { word, isLoading } = useGetWordDetail(wordId)
+  if (!word) return
+  const { name, meaning, pronunciationInfo, category, example } = word
+  return <div>{name}</div>
+}

--- a/src/hooks/admin/useGetDetailWord.ts
+++ b/src/hooks/admin/useGetDetailWord.ts
@@ -1,0 +1,10 @@
+import { getWordDetailById } from '@/api/admin/words'
+import { useQuery } from '@tanstack/react-query'
+
+export const useGetWordDetail = (wordId: number) => {
+  const { data: word, isLoading } = useQuery({
+    queryKey: ['words', 'admin', wordId],
+    queryFn: () => getWordDetailById(wordId),
+  })
+  return { word, isLoading }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  const headers = new Headers(req.headers)
+  headers.set('x-current-path', req.nextUrl.pathname)
+  return NextResponse.next({ headers })
+}

--- a/src/types/word.ts
+++ b/src/types/word.ts
@@ -20,8 +20,17 @@ export type DetailWordType = {
   }
   isMarked: boolean
   bookmarkCount: number
-  example: { text: string; source: string; createdAt: Date }[]
+  example: { text: string; source: string; createdAt: Date }[] | string
   source: string
   createdAt: Date
   updatedAt: Date
 } & SimpleWordType
+
+// 관리자 용어 조회
+export type AdminWordType = Pick<
+  DetailWordType,
+  'id' | 'name' | 'pronunciationInfo' | 'meaning' | 'category' | 'example'
+>
+
+// 관리자 용어 등록 폼 타입
+export type AddWordType = Omit<AdminWordType, 'id'>


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호

- #51 

<br/>

## 📝 작업 내용

- url pathname이 `/admin`으로 시작하는 경우 max-width 적용 X 및 전반적인 레이아웃 변경
  +) server component에서 현재 pathname 받아오기 위해 `/src/middleware.ts` 생성 후 headers 설정
- admin 하위 공통 레이아웃 생성 및 Header 컴포넌트 분리
- 용어 등록 페이지 구현
- 용어 관련 타입 수정 및 추가

<br/>

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/c86fc1ca-2ff8-403c-a910-82989da2548b)


<br/>

## 💬 리뷰 요구사항/참고 사항

