### PR TITLE
fix: admin 용어 등록 폼 resource(출처) 필드 추가

### DIFF
--- a/src/app/admin/words/add/page.tsx
+++ b/src/app/admin/words/add/page.tsx
@@ -19,6 +19,7 @@ export default function AddWordPage() {
     pronunciationInfo: { english: '' },
     category: '비즈니스',
     example: '',
+    resource: '',
   })
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -36,15 +37,15 @@ export default function AddWordPage() {
     } else {
       setWord((prev) => ({ ...prev, [name]: value }))
     }
-    console.log(word)
   }
   function hasEmptyField() {
-    const { name, meaning, pronunciationInfo, example } = word
+    const { name, meaning, pronunciationInfo, example, resource } = word
     return (
       name === '' ||
       meaning === '' ||
       pronunciationInfo.english === '' ||
-      example === ''
+      example === '' ||
+      resource === ''
     )
   }
 
@@ -69,7 +70,6 @@ export default function AddWordPage() {
               onChange={handleChange}
             />
           </label>
-
           <label>
             용어 뜻{' '}
             <Textarea
@@ -88,12 +88,19 @@ export default function AddWordPage() {
               className="bg-white"
             />
           </label>
-
           <label>
             발음
             <Input
               name="pronunciationInfo"
               value={word.pronunciationInfo.english ?? ''}
+              onChange={handleChange}
+            />
+          </label>
+          <label>
+            출처
+            <Input
+              name="resource"
+              value={word.resource ?? ''}
               onChange={handleChange}
             />
           </label>

--- a/src/types/word.ts
+++ b/src/types/word.ts
@@ -29,7 +29,13 @@ export type DetailWordType = {
 // 관리자 용어 조회
 export type AdminWordType = Pick<
   DetailWordType,
-  'id' | 'name' | 'pronunciationInfo' | 'meaning' | 'category' | 'example'
+  | 'id'
+  | 'name'
+  | 'pronunciationInfo'
+  | 'meaning'
+  | 'category'
+  | 'example'
+  | 'resource'
 >
 
 // 관리자 용어 등록 폼 타입


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호

- close #51 

<br/>

## 📝 작업 내용

- admin 용어 등록 페이지 폼 내에서 출처 기입하는 input이 누락되어 추가했습니다.

<br/>

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/6857930b-a5e4-4ec8-9111-e0974eee0766)


<br/>

## 💬 리뷰 요구사항/참고 사항
