### PR TITLE
feat: token 관리 로직 추가

### DIFF
--- a/src/app/google/callback/loading/page.tsx
+++ b/src/app/google/callback/loading/page.tsx
@@ -1,23 +1,28 @@
 'use client'
 
-import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useAuthStore } from '@/store/useAuthStore'
 
 const LoginCallback = () => {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const setAccessToken = useAuthStore((state) => state.setAccessToken)
 
   const accessToken = searchParams.get('accessToken')
   const isSignUp = searchParams.get('isSignUp')
 
   useEffect(() => {
+    setAccessToken(accessToken)
+
     if (accessToken && isSignUp) {
       router.push('/profile')
     }
+
     if (accessToken && isSignUp === 'false') {
       router.push('/home/dictionary')
     }
-  }, [accessToken, isSignUp, router])
+  }, [accessToken, isSignUp, router, setAccessToken])
 
   return <></>
 }

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,6 +1,6 @@
 import { env } from '@/constants/env'
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
-
+import { useAuthStore } from '@/store/useAuthStore'
 const axiosInstance = axios.create({
   baseURL: env.BASE_URL,
   timeout: 10000,
@@ -10,6 +10,12 @@ const axiosInstance = axios.create({
 // 요청 인터셉터
 axiosInstance.interceptors.request.use(
   (config) => {
+    const { accessToken } = useAuthStore.getState()
+
+    if (accessToken && config.headers) {
+      config.headers.set('Authorization', `Bearer ${accessToken}`)
+    }
+
     return config
   },
   (error) => {

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand'
+
+interface AuthState {
+  accessToken: string | null
+  setAccessToken: (token: string | null) => void
+  clearAccessToken: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  accessToken: null,
+  setAccessToken: (token) => set({ accessToken: token }),
+  clearAccessToken: () => set({ accessToken: null }),
+}))
+


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호

<br/>

- #79 

## 📝 작업 내용

<br/>

- 구글 소셜 로그인 구현 완료 및 token관리 로직 추가

## 📸 스크린샷

<br/>

https://github.com/user-attachments/assets/f75ecca6-40ee-4873-bf6d-b593b90259b2


## 💬 리뷰 요구사항/참고 사항

- 구글 로그인시, 동의 화면은 배포 후에 나타납니다
- zustand를 활용해서 토큰을 저장해 요청시 header에 default로 넣어주는 방식으로 구현하였습니다

https://github.com/dnd-side-project/dnd-11th-10-frontend/blob/fa99126331dfe2fec03fb5f77a7d4cc25e8b366e/src/lib/axios.ts#L11-L24

