### PR TITLE
feat: admin 전체 용어 목록 조회 페이지 기능 구현

### DIFF
--- a/src/api/admin/words/index.ts
+++ b/src/api/admin/words/index.ts
@@ -1,7 +1,12 @@
-import { get } from '@/lib/axios'
-import { AdminWordType } from '@/types/word'
+import { get, post } from '@/lib/axios'
+import { AddWordType, AdminWordType } from '@/types/word'
 
 export async function getWordDetailById(wordId: number) {
   const res = await get<AdminWordType>(`/admin/words/${wordId}`)
+  return res
+}
+
+export async function addNewWord(word: AddWordType) {
+  const res = await post('/admin/words', word)
   return res
 }

--- a/src/api/admin/words/index.ts
+++ b/src/api/admin/words/index.ts
@@ -10,3 +10,8 @@ export async function addNewWord(word: AddWordType) {
   const res = await post('/admin/words', word)
   return res
 }
+
+export async function getAllWords() {
+  const res = await get<AdminWordType[]>(`/admin/allwords`)
+  return res
+}

--- a/src/app/admin/words/add/page.tsx
+++ b/src/app/admin/words/add/page.tsx
@@ -16,7 +16,7 @@ export default function AddWordPage() {
   const [word, setWord] = useState<AddWordType>({
     name: '',
     meaning: '',
-    pronunciationInfo: { english: '' },
+    pronunciation: { english: '' },
     category: '비즈니스',
     example: '',
     resource: '',
@@ -32,18 +32,18 @@ export default function AddWordPage() {
         ...prev,
         category: categoryName,
       }))
-    } else if (name === 'pronunciationInfo') {
-      setWord((prev) => ({ ...prev, pronunciationInfo: { english: value } }))
+    } else if (name === 'pronunciation') {
+      setWord((prev) => ({ ...prev, pronunciation: { english: value } }))
     } else {
       setWord((prev) => ({ ...prev, [name]: value }))
     }
   }
   function hasEmptyField() {
-    const { name, meaning, pronunciationInfo, example, resource } = word
+    const { name, meaning, pronunciation, example, resource } = word
     return (
       name === '' ||
       meaning === '' ||
-      pronunciationInfo.english === '' ||
+      pronunciation.english === '' ||
       example === '' ||
       resource === ''
     )
@@ -91,8 +91,8 @@ export default function AddWordPage() {
           <label>
             발음
             <Input
-              name="pronunciationInfo"
-              value={word.pronunciationInfo.english ?? ''}
+              name="pronunciation"
+              value={word.pronunciation.english ?? ''}
               onChange={handleChange}
             />
           </label>

--- a/src/app/admin/words/add/page.tsx
+++ b/src/app/admin/words/add/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { addNewWord } from '@/api/admin/words'
 import Button from '@/components/common/Button'
 import Input from '@/components/common/Input'
 import RadioButton from '@/components/common/RadioButton'
@@ -49,12 +50,21 @@ export default function AddWordPage() {
     )
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (hasEmptyField()) {
       alert('모두 입력해주세요')
       return
     }
-    alert(`${word.name} 용어 등록 완료`)
+    await addNewWord(word)
+    alert('용어 등록 완료')
+    setWord({
+      name: '',
+      meaning: '',
+      pronunciation: { english: '' },
+      category: '비즈니스',
+      example: '',
+      resource: '',
+    })
   }
 
   return (

--- a/src/app/admin/words/page.tsx
+++ b/src/app/admin/words/page.tsx
@@ -1,0 +1,12 @@
+import { getAllWords } from '@/api/admin/words'
+import AdminWordList from '@/components/domain/admin/WordList'
+
+export default async function WordsListPage() {
+  const res = await getAllWords()
+  return (
+    <div className="px-40 mt-8">
+      <p className="text-h2 mb-2">전체 용어</p>
+      <AdminWordList words={res} />
+    </div>
+  )
+}

--- a/src/components/domain/admin/WordList/WordListItem.tsx
+++ b/src/components/domain/admin/WordList/WordListItem.tsx
@@ -1,0 +1,16 @@
+import { AdminWordType } from '@/types/word'
+import Link from 'next/link'
+
+export default function WordListItem({ word }: { word: AdminWordType }) {
+  const { id, name, meaning, category } = word
+  return (
+    <Link
+      href={`/admin/words/${id}`}
+      className="bg-white flex gap-6 justify-around py-4 px-8 mb-1 rounded hover:bg-opacity-60"
+    >
+      <p className="w-64 text-h3">{name}</p>
+      <p className="flex-1 text-ellipsis line-clamp-1">{meaning}</p>
+      <p>{category}</p>
+    </Link>
+  )
+}

--- a/src/components/domain/admin/WordList/index.tsx
+++ b/src/components/domain/admin/WordList/index.tsx
@@ -1,0 +1,14 @@
+import { AdminWordType } from '@/types/word'
+import WordListItem from './WordListItem'
+
+export default function AdminWordList({ words }: { words: AdminWordType[] }) {
+  return (
+    <>
+      <div>
+        {words.map((word, idx) => (
+          <WordListItem key={word.id} word={word} />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,3 +1,3 @@
 export const env = {
-  BASE_URL: process.env.NEXT_PUBLIC_API_URL,
+  BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
 }

--- a/src/types/word.ts
+++ b/src/types/word.ts
@@ -29,14 +29,8 @@ export type DetailWordType = {
 // 관리자 용어 조회
 export type AdminWordType = Pick<
   DetailWordType,
-  | 'id'
-  | 'name'
-  | 'pronunciationInfo'
-  | 'meaning'
-  | 'category'
-  | 'example'
-  | 'resource'
->
+  'id' | 'name' | 'meaning' | 'category' | 'example' | 'resource'
+> & { pronunciation: { english: string } }
 
 // 관리자 용어 등록 폼 타입
 export type AddWordType = Omit<AdminWordType, 'id'>


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호

- close #43 
<br/>

## 📝 작업 내용

- 용어 목록 페이지 UI 작업, 용어 개별 컴포넌트 분리
- 전체 용어 목록 조회 api 연동
- 용어 개별 컴포넌트 클릭 시 개별 상세 페이지로 이동

<br/>

## 📸 스크린샷

<br/>

## 💬 리뷰 요구사항/참고 사항
