### PR TITLE
feat: 용어 상세 페이지 댓글 목록 조회 및 댓글 새로고침 기능 구현

### DIFF
--- a/src/api/comment/index.tsx
+++ b/src/api/comment/index.tsx
@@ -1,9 +1,17 @@
 import { get } from '@/lib/axios'
-import { SimpleCommentType } from '@/types/comment'
+import { DetailCommentType, SimpleCommentType } from '@/types/comment'
 import { SuccessResponse } from '@/types/response'
 
 export async function getPopularComments() {
   const res =
     await get<SuccessResponse<SimpleCommentType[]>>('/comments/popular')
   return res.comments
+}
+
+// 용어 상세 페이지 댓글 목록 조회
+export async function getCommentsByWordId(wordId: number) {
+  const res = await get<SuccessResponse<DetailCommentType[]>>(
+    `/words/${wordId}/comments`,
+  )
+  return res.comments as DetailCommentType[]
 }

--- a/src/app/words/[slug]/page.tsx
+++ b/src/app/words/[slug]/page.tsx
@@ -29,7 +29,7 @@ export default async function WordDetailPage({
         <WordInfo wordId={wordId} />
       </HydrationBoundary>
       <ContactButton />
-      <CommentsList />
+      <CommentsList wordId={wordId} />
     </div>
   )
 }

--- a/src/components/domain/wordDetail/CommentTextarea/index.tsx
+++ b/src/components/domain/wordDetail/CommentTextarea/index.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 
 const [smallHeight, largeHeight] = ['56px', '76px']
 
-export default function CommentTextarea({ wordId }: { wordId: string }) {
+export default function CommentTextarea({ wordId }: { wordId: number }) {
   const [value, setValue] = useState<string>('')
   const [focused, setFocused] = useState(false)
   const [height, setHeight] = useState<number | string>(smallHeight)

--- a/src/components/domain/wordDetail/CommentsList/index.tsx
+++ b/src/components/domain/wordDetail/CommentsList/index.tsx
@@ -1,6 +1,5 @@
 'use client'
 import Image from 'next/image'
-import { Comments } from './data'
 import SortButton from '@/components/common/SortButton'
 import { useState } from 'react'
 import useUIStore from '@/store/useUIStore'
@@ -8,71 +7,78 @@ import FilterBottomSheet from '@/components/shared/FilterBottomSheet'
 import CommentItem from '@/components/shared/CommentItem'
 import CommentBottomSheet from '@/components/shared/CommentBottomSheet'
 import CommentInput from '../CommentTextarea'
-import { usePathname } from 'next/navigation'
 import CheckboxBottomSheet from '@/components/shared/CheckboxBottomSheet'
 import Snackbar from '@/components/shared/Snackbar'
+import { useGetComments } from '@/hooks/comment/useGetComments'
 
-export default function CommentsList() {
-  const pathname = usePathname()
-  const wordId = pathname.split('/').at(-1) ?? ''
-
+export default function CommentsList({ wordId }: { wordId: number }) {
   const [sortType, setSortType] = useState('좋아요순')
   const [targetId, setTargetId] = useState<number>()
   const { bottomSheetType, openBottomSheet } = useUIStore()
+  const { comments, isFetching, isLoading, refetch } = useGetComments(wordId)
+  const commentsLength = comments?.length as number
 
-  const handleRefresh = () => {
-    // 댓글 새로고침
-  }
+  if (!comments && (!isFetching || !isLoading)) return
   return (
     <>
-      <div className="w-full flex flex-col gap-2 mt-10">
-        <div className="flex justify-between px-4 mb-5">
-          <div className="flex items-center gap-2">
-            <p className="text-h3">
-              <span className="text-primary-400">{Comments.length}</span>개의
-              댓글
-            </p>
-            <Image
-              alt="refresh"
-              src={'/icons/refresh.svg'}
-              width={24}
-              height={24}
-              onClick={handleRefresh}
-              className="cursor-pointer"
-            />
-          </div>
-          <SortButton
-            sortBy={sortType}
-            onClick={() => openBottomSheet('filter')}
+      {isFetching || isLoading ? (
+        <div className="h-72 flex items-center justify-center">
+          <Image
+            src={'/gif/loading.gif'}
+            alt="loading.gif"
+            width={80}
+            height={80}
           />
         </div>
-        <div className="w-full box-border px-4">
-          <CommentInput wordId={wordId} />
-        </div>
-        {/* 댓글 리스트 */}
-        {Comments.length > 0 ? (
-          Comments.map((comment, idx) => {
-            return (
+      ) : (
+        <div className="w-full flex flex-col gap-2 mt-10">
+          <div className="flex justify-between px-4 mb-5">
+            <div className="flex items-center gap-2">
+              <p className="text-h3">
+                <span className="text-primary-400">{commentsLength}</span>개의
+                댓글
+              </p>
+              <Image
+                alt="refresh"
+                src={'/icons/refresh.svg'}
+                width={24}
+                height={24}
+                onClick={() => refetch()}
+                className="cursor-pointer"
+              />
+            </div>
+            <SortButton
+              sortBy={sortType}
+              onClick={() => openBottomSheet('filter')}
+            />
+          </div>
+          <div className="w-full box-border px-4">
+            <CommentInput wordId={wordId} />
+          </div>
+          {/* 댓글 리스트 */}
+          {commentsLength > 0 ? (
+            comments?.map((comment, idx) => (
               <CommentItem
                 key={comment.id}
                 comment={comment}
                 setTargetId={setTargetId}
               />
-            )
-          })
-        ) : (
-          <div className="w-full flex flex-col gap-5 items-center py-10">
-            {/* 일러 변경 필요 */}
-            <Image
-              alt="image"
-              src={'/images/logo.svg'}
-              width={80}
-              height={80}
-            />
-            <p className="text-onSurface-100">첫 댓글을 남겨보세요.</p>
-          </div>
-        )}
-      </div>
+            ))
+          ) : (
+            <div className="w-full flex flex-col gap-5 items-center py-10">
+              {/* 일러 변경 필요 */}
+              <Image
+                alt="image"
+                src={'/images/logo.svg'}
+                width={80}
+                height={80}
+              />
+              <p className="text-onSurface-100">첫 댓글을 남겨보세요.</p>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* 정렬 bottomSheet */}
       <FilterBottomSheet
         isOpen={bottomSheetType === 'filter'}

--- a/src/hooks/comment/useGetComments.ts
+++ b/src/hooks/comment/useGetComments.ts
@@ -1,0 +1,15 @@
+import { getCommentsByWordId } from '@/api/comment'
+import { useQuery } from '@tanstack/react-query'
+
+export const useGetComments = (wordId: number) => {
+  const {
+    data: comments,
+    isFetching,
+    isLoading,
+    refetch,
+  } = useQuery({
+    queryKey: ['words', 'comments', wordId],
+    queryFn: () => getCommentsByWordId(wordId),
+  })
+  return { comments, isFetching, isLoading, refetch }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
> ex) - #이슈번호

- close #115 

<br/>

## 📝 작업 내용

- 용어 상세 페이지 내 댓글 목록 조회 api 연동
- useGetComments custom hook 내에서 refetch 함수 반환하여 댓글 새로고침 기능 구현
- isFetching, isLoading 상태인 경우 loading spinner 적용

<br/>

## 📸 스크린샷

<br/>

## 💬 리뷰 요구사항/참고 사항
